### PR TITLE
Change generic contraint from TableEntity to ITableEntity

### DIFF
--- a/src/TableStorage.Abstractions/ITableStoreFactory.cs
+++ b/src/TableStorage.Abstractions/ITableStoreFactory.cs
@@ -4,7 +4,7 @@ namespace TableStorage.Abstractions
 {
     public interface ITableStoreFactory
     {
-        ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString) where T : TableEntity, new();
-        ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString, int retries, double retryWaitTimeInSeconds) where T : TableEntity, new();
+        ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString) where T : class, ITableEntity, new();
+        ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString, int retries, double retryWaitTimeInSeconds) where T : class, ITableEntity, new();
     }
 }

--- a/src/TableStorage.Abstractions/TableStore.cs
+++ b/src/TableStorage.Abstractions/TableStore.cs
@@ -14,7 +14,7 @@ namespace TableStorage.Abstractions
     /// Table store repository
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class TableStore<T> : ITableStore<T> where T : TableEntity, new()
+    public class TableStore<T> : ITableStore<T> where T : class,ITableEntity, new()
     {
         /// <summary>
         /// The cloud table

--- a/src/TableStorage.Abstractions/TableStoreFactory.cs
+++ b/src/TableStorage.Abstractions/TableStoreFactory.cs
@@ -4,12 +4,12 @@ namespace TableStorage.Abstractions
 {
     public class TableStoreFactory : ITableStoreFactory
     {
-        public ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString) where T : TableEntity, new()
+        public ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString) where T : class,ITableEntity, new()
         {
             return new TableStore<T>(tableName, storageConnectionString);
         }
 
-        public ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString, int retries, double retryWaitTimeInSeconds) where T : TableEntity, new()
+        public ITableStore<T> CreateTableStore<T>(string tableName, string storageConnectionString, int retries, double retryWaitTimeInSeconds) where T : class, ITableEntity, new()
         {
             return new TableStore<T>(tableName, storageConnectionString, retries, retryWaitTimeInSeconds);
         }


### PR DESCRIPTION
This change is simple.... to change the generic constraint in ITableStore to be the less restrictive ITableEntity.

My motivation for this is that DynamicTableEntity unfortunately does not inherit from TableEntity, but _does_ implement ITableStore.

And the reason I want to use DynamicTableEntity is one of pure laziness.... :) 

I tend to not like to directly use TableEntity classes in my domain layer because things like "RowKey", "PartitionKey" and "Etag" don't make sense there; so I tend to map my POCO domain objects to entity objects, and then use TableStorage.Abstractions to persist those.  Often times however, the mapping is almost one to one, which gets tedious.  As such, I created a library to help map POCOs to TableEntities ( https://github.com/giometrix/TableStorage.Abstractions.TableEntityConverters ).  This works via DynamicTableEntities, which are currently incompatible with your library.  With the change in this pull request, however, I can do something like this:

```csharp
var tsf = new TableStoreFactory();
_accountsTableStore = tsf.CreateTableStore<DynamicTableEntity>(accountsTableName,
				connectionString, retries, retryWaitTimeInSeconds);


	public Task AddNewAccountAsync(Guid accountId, string name, string phoneNumber)
		{
                        //notice this is a POCO not a table Entity
			return _accountsTableStore.InsertAsync(
				new AccountSyncDetails
				{
					Name= name,
                                        PhoneNumber = phoneNumber
				}.ToTableEntity(AccountSyncDetailsPartitionKey, accountId)); 
                                // in this example we want all accounts in the same partition
		}
```

This simple change + combination with my little library saved me quite a bit of code since normally I would have an entity version of many of my domain objects.

Let me know if this change is problematic for you; if it is I'll try to figure something else out; I'd like to make my library work well with yours (although it does not rely on it).