### PR TITLE
Move to .NET Standard 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 **/obj
 **/bin
 /.vs
+*.user

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TableStorage.Abstractions
-Repository wrapper for Azure Table Storage in C# .NET 4.5.2, .NET 4.6, .NET 4.6.1, NETCoreApp 2.0, NETCoreApp 2.1
+Repository wrapper for Azure Table Storage in C# .NET 4.5.2, .NET 4.6, and .NET Standard 2.0.
 
 <image src="https://ci.appveyor.com/api/projects/status/github/Tazmainiandevil/TableStorage.Abstractions?branch=master&svg=true">
 <a href="https://badge.fury.io/nu/TableStorage.Abstractions"><img src="https://badge.fury.io/nu/TableStorage.Abstractions.svg" alt="NuGet version" height="18"></a>

--- a/src/TableStorage.Abstractions/TableStorage.Abstractions.csproj
+++ b/src/TableStorage.Abstractions/TableStorage.Abstractions.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;net461;netcoreApp2.0;netcoreApp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452;net46;</TargetFrameworks>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <Version>1.0.0</Version>
     <PackageVersion>1.0.0</PackageVersion>
   </PropertyGroup>
-
+	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<DefineConstants>NETSTANDARD2_0</DefineConstants>
+	</PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="7.6.103" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />


### PR DESCRIPTION
Hello,

I noticed that this project was ported to compile to .net core 2.0 and 2.1.  While this is fantastic, I think it would be better if it could compile to .net standard 2.0 instead.  As-is, you'd need to target each version of .net core as they are released (e.g. .net core 2.2), further, it leaves out the ability to use this library outside of the targeted frameworks, such as Xamarin (though admittedly I don't see that being too popular).  Most important though, it leaves out the ability to use the library in libraries that want to target .Net Standard.

Please take a look at this PR and see if it continues to satisfy your needs while targeting .net standard 2.0 (it should).

Happy Holidays!
Gio