### PR TITLE
Add DeleteAllAsync & DeleteByPartitionAsync

### DIFF
--- a/src/TableStorage.Abstractions/Store/ITableStore.cs
+++ b/src/TableStorage.Abstractions/Store/ITableStore.cs
@@ -96,6 +96,19 @@ namespace TableStorage.Abstractions.Store
         Task DeleteUsingWildcardEtagAsync(T record);
 
         /// <summary>
+        /// Delete records by partition key
+        /// </summary>
+        /// <param name="partitionKey"></param>
+        /// <returns></returns>
+        Task DeleteByPartitionAsync(string partitionKey);
+
+        /// <summary>
+        /// Delete all records in the table
+        /// </summary>
+        /// <returns></returns>
+        Task DeleteAllAsync();
+
+        /// <summary>
         /// Get an record by partition and row key
         /// </summary>
         /// <param name="partitionKey"></param>

--- a/tests/TableStorage.Abstractions.Tests/Store/TableStoreDeleteTests.cs
+++ b/tests/TableStorage.Abstractions.Tests/Store/TableStoreDeleteTests.cs
@@ -48,7 +48,7 @@ namespace TableStorage.Abstractions.Tests.Store
             result.Count().Should().Be(1);
         }
 
-        
+
         [Fact]
         public async Task delete_a_dynamic_entry_and_the_record_count_should_decrease()
         {
@@ -75,6 +75,36 @@ namespace TableStorage.Abstractions.Tests.Store
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithMessage("Value cannot be null.\r\nParameter name: record");
+        }
+
+        [Fact]
+        public async Task delete_all_records_and_the_record_count_should_be_zero()
+        {
+            // Arrange
+            await TestDataHelper.SetupRecords(_tableStorageDynamic);
+
+            // Act
+            await _tableStorage.DeleteAllAsync();
+            var result = await _tableStorage.GetAllRecordsAsync();
+
+            // Assert
+            result.Count().Should().Be(0);
+        }
+
+        [Fact]
+        public async Task delete_records_by_partitionkey_and_record_count_by_partition_should_be_zero()
+        {
+            // Arrange
+            await TestDataHelper.SetupRecords(_tableStorageDynamic);
+
+            // Act
+            await _tableStorage.DeleteByPartitionAsync("Smith");
+            var resultEmpty = await _tableStorage.GetByPartitionKeyAsync("Smith");
+            var resultNotEmpty = await _tableStorage.GetByPartitionKeyAsync("Jones");
+
+            // Assert
+            resultEmpty.Count().Should().Be(0);
+            resultNotEmpty.Count().Should().NotBe(0);
         }
     }
 }


### PR DESCRIPTION
This PR adds DeleteAllAsync() and DeleteByPartitionAsync() methods.
DeleteAllAsync() gets all records and deletes by Partition to improve the performance.

Most of the code was inspired / borrowed from this article:
https://blog.bitscry.com/2019/03/25/efficiently-deleting-rows-from-azure-table-storage/

I haven't done any performance tests on batch sizes but I'm coming across the "100" value as a good size for batch operations a lot so I think it makes sense to split them like this.

I also added positive tests for the new methods
FYI Unfortunately I can't seem to run negative tests on my machine as the Exception messages are translated into my local language (German) and therefore are failing. 🙄

Let me know if you have any thoughts on the code.